### PR TITLE
expose a builder for QuicP2p

### DIFF
--- a/examples/bootstrap_node.rs
+++ b/examples/bootstrap_node.rs
@@ -26,7 +26,7 @@ extern crate serde_derive;
 mod common;
 use common::Rpc;
 
-use quic_p2p::{Config, Event, NodeInfo, Peer, QuicP2p, SerialisableCertificate};
+use quic_p2p::{Builder, Config, Event, NodeInfo, Peer, SerialisableCertificate};
 
 use bincode;
 use bytes::Bytes;
@@ -81,19 +81,17 @@ fn main() -> Result<(), io::Error> {
         let our_complete_cert = SerialisableCertificate::default();
         let cert_der = our_complete_cert.cert_der.clone();
         (
-            QuicP2p::with_config(
-                ev_tx,
-                Config {
+            unwrap!(Builder::new(ev_tx)
+                .with_config(Config {
                     our_complete_cert: Some(our_complete_cert),
                     port: Some(bootstrap_node_config.port),
                     ip: Some(IpAddr::V4(bootstrap_node_config.ip)),
                     ..Default::default()
-                },
-            ),
+                },)
+                .build()),
             cert_der,
         )
     };
-    unwrap!(qp2p.start_listening());
 
     info!("QuicP2p started on port {}", bootstrap_node_config.port);
 

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -22,7 +22,7 @@ use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use serde_json;
 
-use quic_p2p::{Config, Event, Peer, QuicP2p};
+use quic_p2p::{Builder, Config, Event, Peer, QuicP2p};
 use std::sync::{Arc, Mutex};
 
 struct PeerList {
@@ -82,15 +82,13 @@ fn main() {
 
     let (ev_tx, ev_rx) = channel();
 
-    let mut qp2p = QuicP2p::with_config(
-        ev_tx,
-        Config {
+    let mut qp2p = unwrap!(Builder::new(ev_tx)
+        .with_config(Config {
             port,
             ..Default::default()
-        },
-    );
+        },)
+        .build());
 
-    unwrap!(qp2p.start_listening());
     println!("QuicP2p started");
 
     let peerlist = Arc::new(Mutex::new(PeerList::new()));

--- a/src/bootstrap_cache.rs
+++ b/src/bootstrap_cache.rs
@@ -61,9 +61,8 @@ impl BootstrapCache {
         })
     }
 
-    #[allow(unused)]
-    pub fn peers(&self) -> &VecDeque<NodeInfo> {
-        &self.peers
+    pub fn peers_mut(&mut self) -> &mut VecDeque<NodeInfo> {
+        &mut self.peers
     }
 
     /// Caches given peer if it's not in hard coded contacts.
@@ -184,10 +183,10 @@ mod tests {
                 cache.add_peer(rand_peer());
             }
 
-            assert_eq!(cache.peers().len(), 10);
+            assert_eq!(cache.peers.len(), 10);
 
             let cache = unwrap!(BootstrapCache::try_new(&dirs, HashSet::new()));
-            assert_eq!(cache.peers().len(), 10);
+            assert_eq!(cache.peers.len(), 10);
         }
 
         #[test]
@@ -202,7 +201,7 @@ mod tests {
             cache.add_peer(peer1.clone());
             cache.add_peer(peer2.clone());
 
-            let peers: Vec<NodeInfo> = cache.peers().iter().cloned().collect();
+            let peers: Vec<NodeInfo> = cache.peers.iter().cloned().collect();
             assert_eq!(peers, vec![peer2]);
         }
     }
@@ -223,7 +222,7 @@ mod tests {
 
             cache.move_to_cache_top(peer2.clone());
 
-            let peers: Vec<NodeInfo> = cache.peers().iter().cloned().collect();
+            let peers: Vec<NodeInfo> = cache.peers.iter().cloned().collect();
             assert_eq!(peers, vec![peer1, peer3, peer2]);
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use crate::NodeInfo;
+use crate::{NodeInfo, R};
 use std::net::IpAddr;
 
 /// QuicP2p configurations
@@ -40,12 +40,34 @@ pub struct Config {
 }
 
 impl Config {
+    /// Try and read the config off the disk first and failing that create a default one. It will
+    /// try write the default constructed one to the disk.
     pub fn read_or_construct_default() -> Config {
-        // FIXME 1st try reading from the disk
-        Default::default()
+        match Self::read_config() {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                debug!("Failed to read off the disk: {:?} - {}", e, e);
+                let cfg = Self::with_default_cert();
+                // FIXME write this config to the disk. If error then simply log an `info!` and
+                // carry on - don't error out completely
+                cfg
+            }
+        }
     }
 
+    // FIXME Implement this
+    /// Read the Config off the disk
+    pub fn read_config() -> R<Config> {
+        Err(From::from(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Unimplemented",
+        )))
+    }
+
+    /// Create a default Config with random Certificate
     pub fn with_default_cert() -> Config {
+        trace!("Constructing default Config");
+
         Self {
             our_complete_cert: Some(Default::default()),
             ..Self::default()


### PR DESCRIPTION
This allows the user for specifying their own list of proxies either in addition to or as a replacement of bootstrap-cache which might be already present on the disk