### PR TITLE
Add tests for malicious client scenarios

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -95,11 +95,17 @@ fn main() {
                 };
                 let mut peerlist = peerlist.lock().unwrap();
                 let result = match cmd {
-                    "ourinfo" => Ok(print_ourinfo(&mut qp2p)),
+                    "ourinfo" => {
+                        print_ourinfo(&mut qp2p);
+                        Ok(())
+                    }
                     "addpeer" => peerlist
                         .insert_from_json(&args.collect::<Vec<_>>().join(" "))
                         .and(Ok(())),
-                    "listpeers" => Ok(peerlist.list()),
+                    "listpeers" => {
+                        peerlist.list();
+                        Ok(())
+                    }
                     "delpeer" => args
                         .next()
                         .ok_or("Missing index argument")
@@ -109,9 +115,12 @@ fn main() {
                     "send" => on_cmd_send(&mut args, &peerlist, &mut qp2p),
                     "sendrand" => on_cmd_send_rand(&mut args, &peerlist, &mut qp2p),
                     "quit" | "exit" => break 'outer,
-                    "help" => Ok(println!(
-                        "Commands: ourinfo, addpeer, listpeers, delpeer, send, quit, exit, help"
-                    )),
+                    "help" => {
+                        println!(
+                            "Commands: ourinfo, addpeer, listpeers, delpeer, send, quit, exit, help"
+                        );
+                        Ok(())
+                    }
                     _ => Err("Unknown command"),
                 };
                 if let Err(msg) = result {

--- a/examples/client_node.rs
+++ b/examples/client_node.rs
@@ -222,10 +222,10 @@ fn random_data_with_hash(size: usize) -> Vec<u8> {
 }
 
 fn hash_correct(data: &[u8]) -> bool {
-    let encoded_hash = ((data[0] as u32) << 24)
-        | ((data[1] as u32) << 16)
-        | ((data[2] as u32) << 8)
-        | data[3] as u32;
+    let encoded_hash = (u32::from(data[0]) << 24)
+        | (u32::from(data[1]) << 16)
+        | (u32::from(data[2]) << 8)
+        | u32::from(data[3]);
     let actual_hash = crc32::checksum_ieee(&data[4..]);
     encoded_hash == actual_hash
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -30,3 +30,83 @@ pub fn start() {
         let _ = connect::connect_to(proxy, None, Some(&maker));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::new_random_qp2p_for_unit_test;
+    use crate::{Builder, Config, Event};
+    use std::collections::HashSet;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    // Try to bootstrap to 4 different peer sequentially. Use an artificial delay for 3 of the peers.
+    // Make sure in the end we have only one bootstrapped connection (all other connections are
+    // supposed to be dropped).
+    #[test]
+    fn bootstrap_to_only_one_node_with_delays() {
+        test_bootstrap_to_multiple_peers(4, Some(10));
+    }
+
+    // Try to bootstrap to 4 different peer at once.
+    // Make sure in the end we have only one bootstrapped connection (all other connections are
+    // supposed to be dropped).
+    #[test]
+    fn bootstrap_to_only_one_node_without_delays() {
+        test_bootstrap_to_multiple_peers(4, None);
+    }
+
+    fn test_bootstrap_to_multiple_peers(num_conns: u64, delay_ms: Option<u64>) {
+        let mut bs_nodes = Vec::with_capacity(num_conns as usize);
+        let mut bs_peer_addrs = HashSet::with_capacity(num_conns as usize);
+        let mut hcc_contacts = HashSet::with_capacity(num_conns as usize);
+
+        // Spin up 4 peers that we'll use for hardcoded contacts.
+        for i in 0..num_conns {
+            let (tx, rx) = mpsc::channel();
+            let mut qp2p = unwrap!(Builder::new(tx)
+                .with_config(Config {
+                    ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+                    port: Some(0),
+                    ..Default::default()
+                })
+                .build());
+
+            if let Some(delay_ms) = delay_ms {
+                qp2p.set_connect_delay(i * delay_ms);
+            }
+
+            let ci_info = unwrap!(qp2p.our_connection_info());
+
+            bs_peer_addrs.insert(ci_info.peer_addr);
+            hcc_contacts.insert(ci_info);
+            bs_nodes.push((rx, qp2p));
+        }
+
+        // Create a client and bootstrap to 4 of the peers we created previously.
+        let (mut qp2p0, rx0) = new_random_qp2p_for_unit_test(false, hcc_contacts);
+        qp2p0.bootstrap();
+
+        match unwrap!(rx0.recv()) {
+            Event::BootstrappedTo { node, .. } => {
+                assert!(bs_peer_addrs.contains(&node.peer_addr));
+            }
+            ev => panic!("Unexpected event: {:?}", ev),
+        }
+
+        thread::sleep(Duration::from_millis(if let Some(delay_ms) = delay_ms {
+            num_conns * delay_ms + delay_ms
+        } else {
+            100
+        }));
+
+        // We expect only 1 bootstrap connection to succeed.
+        let conns_count = unwrap!(qp2p0.connections(|c| {
+            c.iter()
+                .filter(|(_pa, conn)| conn.to_peer.is_established())
+                .count()
+        }));
+        assert_eq!(conns_count, 1);
+    }
+}

--- a/src/bootstrap_cache.rs
+++ b/src/bootstrap_cache.rs
@@ -121,7 +121,7 @@ impl BootstrapCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::testing::{rand_node_info, test_dirs};
+    use crate::test_utils::{rand_node_info, test_dirs};
 
     mod add_peer {
         use super::*;

--- a/src/communicate.rs
+++ b/src/communicate.rs
@@ -441,21 +441,22 @@ fn handle_echo_resp(our_ext_addr: SocketAddr, inform_tx: Option<Sender<SocketAdd
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils;
-    use crate::utils::testing::{rand_node_info, test_dirs};
+    use crate::test_utils::{
+        new_random_qp2p_for_unit_test, rand_node_info, test_dirs, write_to_bi_stream,
+    };
     use std::collections::HashSet;
     use std::sync::mpsc;
 
     // Test for the case of bi-directional stream usage attempt.
     #[test]
     fn disallow_bidirectional_streams() {
-        let (mut qp2p0, rx0) = test_utils::new_random_qp2p_for_unit_test(false, Default::default());
+        let (mut qp2p0, rx0) = new_random_qp2p_for_unit_test(false, Default::default());
         let qp2p0_info = unwrap!(qp2p0.our_connection_info());
 
         let (mut qp2p1, rx1) = {
             let mut hcc: HashSet<_> = Default::default();
             assert!(hcc.insert(qp2p0_info.clone()));
-            test_utils::new_random_qp2p_for_unit_test(true, hcc)
+            new_random_qp2p_for_unit_test(true, hcc)
         };
         let qp2p1_info = unwrap!(qp2p1.our_connection_info());
 
@@ -465,10 +466,7 @@ mod tests {
 
         // Create a bi-directional stream and write data
         qp2p1.el.post(move || {
-            test_utils::write_to_bi_stream(
-                qp2p0_info.peer_addr,
-                WireMsg::UserMsg(From::from("123")),
-            );
+            write_to_bi_stream(qp2p0_info.peer_addr, WireMsg::UserMsg(From::from("123")));
         });
 
         // The connection should fail because we don't allow bi-directional streams

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,8 +202,8 @@ fn config_path(user_override: Option<&Dirs>) -> R<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::test_dirs;
     use crate::utils;
-    use crate::utils::testing::test_dirs;
 
     #[test]
     fn config_create_read_and_write() {

--- a/src/connection/from_peer.rs
+++ b/src/connection/from_peer.rs
@@ -63,7 +63,8 @@ impl fmt::Debug for FromPeer {
                 "FromPeer::Established with {} pending reads",
                 pending_reads.len()
             ),
-            ref blah => write!(f, "{:?}", blah),
+            FromPeer::NoConnection => write!(f, "FromPeer::NoConnection"),
+            FromPeer::NotNeeded => write!(f, "FromPeer::NotNeeded"),
         }
     }
 }

--- a/src/connection/to_peer.rs
+++ b/src/connection/to_peer.rs
@@ -79,7 +79,8 @@ impl fmt::Debug for ToPeer {
                 pending_sends.len()
             ),
             ToPeer::Established { .. } => write!(f, "ToPeer::Established"),
-            ref blah => write!(f, "{:?}", blah),
+            ToPeer::NoConnection => write!(f, "ToPeer::NoConnection"),
+            ToPeer::NotNeeded => write!(f, "ToPeer::NotNeeded"),
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -26,7 +26,7 @@ pub fn initialise_ctx(context: Context) {
     CTX.with(|ctx_refcell| {
         let mut ctx = ctx_refcell.borrow_mut();
         if ctx.is_some() {
-            panic!("Context already initialised !");
+            panic!("Context already initialised!");
         } else {
             *ctx = Some(context);
         }
@@ -42,7 +42,7 @@ pub fn is_ctx_initialised() -> bool {
     })
 }
 
-/// Obtain a referece to the `Context`. This will panic if the `Context` has not be set in the
+/// Obtain a reference to the `Context`. This will panic if the `Context` has not been set in the
 /// current thread context.
 pub fn ctx<F, R>(f: F) -> R
 where
@@ -53,12 +53,12 @@ where
         if let Some(ctx) = ctx.as_ref() {
             f(ctx)
         } else {
-            panic!("Context not initialised !");
+            panic!("Context not initialised!");
         }
     })
 }
 
-/// Obtain a mutable referece to the `Context`. This will panic if the `Context` has not be set in
+/// Obtain a mutable reference to the `Context`. This will panic if the `Context` has not been set in
 /// the current thread context.
 pub fn ctx_mut<F, R>(f: F) -> R
 where
@@ -69,7 +69,7 @@ where
         if let Some(ctx) = ctx.as_mut() {
             f(ctx)
         } else {
-            panic!("Context not initialised !");
+            panic!("Context not initialised!");
         }
     })
 }
@@ -86,7 +86,7 @@ pub struct Context {
     pub keep_alive_interval_msec: u32,
     pub our_type: OurType,
     pub bootstrap_cache: BootstrapCache,
-    quic_ep: quinn::Endpoint,
+    pub(crate) quic_ep: quinn::Endpoint,
 }
 
 impl Context {
@@ -115,6 +115,7 @@ impl Context {
         }
     }
 
+    #[cfg(not(test))]
     pub fn quic_ep(&self) -> &quinn::Endpoint {
         &self.quic_ep
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,13 @@ pub struct QuicP2p {
 }
 
 impl QuicP2p {
-    /// Bootstrap to a proxy
+    /// Bootstrap to the network.
+    ///
+    /// Bootstrap concept is different from "connect" in several ways: `bootstrap()` will try to
+    /// connect to all peers which are specified in the config (`hard_coded_contacts`) or were
+    /// previously cached. If one bootstrap connection succeeds, all other connections will be dropped.
+    ///
+    /// In case of success `Event::BootstrapedTo` will be fired. On error quic-p2p will fire `Event::BootstrapFailure`.
     pub fn bootstrap(&mut self) {
         self.el.post(|| {
             bootstrap::start();

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -8,10 +8,11 @@
 // Software.
 
 use crate::communicate;
-use crate::connection::{Connection, FromPeer, QConn, ToPeer};
+use crate::connection::{BootstrapGroupRef, Connection, FromPeer, QConn, ToPeer};
 use crate::context::ctx_mut;
 use crate::event::Event;
 use crate::utils;
+use crate::Error;
 use crate::NodeInfo;
 use tokio::prelude::{Future, Stream};
 use tokio::runtime::current_thread;
@@ -28,6 +29,12 @@ pub fn listen(incoming_connections: quinn::Incoming) {
     current_thread::spawn(leaf);
 }
 
+enum Action {
+    HandleDuplicate(QConn),
+    HandleAlreadyBootstrapped,
+    Continue(Option<BootstrapGroupRef>),
+}
+
 fn handle_new_conn(
     conn_driver: quinn::ConnectionDriver,
     q_conn: quinn::Connection,
@@ -41,7 +48,7 @@ fn handle_new_conn(
         utils::handle_communication_err(peer_addr, &From::from(e), "Driver failed", None);
     }));
 
-    let is_duplicate = ctx_mut(|c| {
+    let state = ctx_mut(|c| {
         let event_tx = c.event_tx.clone();
         let conn = c
             .connections
@@ -53,7 +60,7 @@ fn handle_new_conn(
                 pending_reads: Default::default(),
             };
 
-            if let ToPeer::Established {
+            let bootstrap_group = if let ToPeer::Established {
                 ref peer_cert_der, ..
             } = conn.to_peer
             {
@@ -61,11 +68,15 @@ fn handle_new_conn(
                     peer_addr,
                     peer_cert_der: peer_cert_der.clone(),
                 };
+                let mut bootstrap_group = None;
 
                 // TODO come back to all the connected-to events and see if we are handling all
                 // cases
                 let event = if let Some(bootstrap_group_ref) = conn.bootstrap_group_ref.take() {
-                    bootstrap_group_ref.terminate_group(true);
+                    if bootstrap_group_ref.is_bootstrap_successful_yet() {
+                        return Action::HandleAlreadyBootstrapped;
+                    }
+                    bootstrap_group = Some(bootstrap_group_ref);
                     Event::BootstrappedTo { node: node_info }
                 } else {
                     Event::ConnectedTo {
@@ -76,17 +87,32 @@ fn handle_new_conn(
                 if let Err(e) = c.event_tx.send(event) {
                     info!("ERROR in informing user about a new peer: {:?} - {}", e, e);
                 }
-            }
-            None
+
+                bootstrap_group
+            } else {
+                None
+            };
+            Action::Continue(bootstrap_group)
         } else {
-            Some(q_conn)
+            Action::HandleDuplicate(q_conn)
         }
     });
 
-    if let Some(_q_conn) = is_duplicate {
-        debug!("Not allowing duplicate connection from peer: {}", peer_addr);
-        return;
+    match state {
+        Action::HandleDuplicate(_q_conn) => {
+            debug!("Not allowing duplicate connection from peer: {}", peer_addr);
+        }
+        Action::HandleAlreadyBootstrapped => crate::utils::handle_communication_err(
+            peer_addr,
+            &Error::ConnectionCancelled,
+            "Connection already bootstrapped",
+            None,
+        ),
+        Action::Continue(bootstrap_group) => {
+            if let Some(bootstrap_group_ref) = bootstrap_group {
+                bootstrap_group_ref.terminate_group(true);
+            }
+            communicate::read_from_peer(peer_addr, incoming_streams);
+        }
     }
-
-    communicate::read_from_peer(peer_addr, incoming_streams);
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -8,28 +8,147 @@
 // Software.
 
 use crate::config::{Config, SerialisableCertificate};
-use crate::connection::{FromPeer, QConn, ToPeer};
+use crate::connection::{Connection, FromPeer, QConn, ToPeer};
 use crate::context::ctx;
+use crate::context::Context;
 use crate::dirs::{Dirs, OverRide};
 use crate::event::Event;
+use crate::utils::R;
 use crate::wire_msg::WireMsg;
 use crate::{communicate, Builder, NodeInfo, Peer, QuicP2p};
 use rand::Rng;
-use std::collections::HashSet;
-use std::env;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver};
-use tokio::prelude::Future;
+use std::{
+    env,
+    ops::Deref,
+    time::{Duration, Instant},
+};
+use tokio::prelude::{future::Either, Future};
 use tokio::runtime::current_thread;
+use tokio::timer::Delay;
+
+thread_local! {
+    static TEST_CTX: RefCell<Option<TestContext>> = RefCell::new(None);
+}
+
+/// Obtain a mutable referece to the `TestContext`. This initialise `TestContext` with a default value
+/// if it has not been set in the current thread context.
+fn test_ctx_mut<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut TestContext) -> R,
+{
+    TEST_CTX.with(|ctx_refcell| {
+        let mut ctx = ctx_refcell.borrow_mut();
+        if let Some(ctx) = ctx.as_mut() {
+            f(ctx)
+        } else {
+            let mut new_ctx = Default::default();
+            let res = f(&mut new_ctx);
+            *ctx = Some(new_ctx);
+            res
+        }
+    })
+}
+
+/// Obtain a reference to the `TestContext`. This will use the default `TestContext` if it has not been set
+/// in the current thread context.
+fn test_ctx<F, R>(f: F) -> R
+where
+    F: FnOnce(&TestContext) -> R,
+{
+    TEST_CTX.with(|ctx_refcell| {
+        let ctx = ctx_refcell.borrow();
+        if let Some(ctx) = ctx.as_ref() {
+            f(ctx)
+        } else {
+            f(&Default::default())
+        }
+    })
+}
+
+/// Newtype wrapper around `quinn::Endpoint` to allow creating artificial delays for outgoing connections.
+pub(crate) struct EndpointWrap<'a>(&'a quinn::Endpoint);
+
+impl<'a> EndpointWrap<'a> {
+    /// Wraps around `quinn::Endpoint::connect_with` and optionally creates an artificial delay.
+    /// Use `test_ctx` to set the delay.
+    pub fn connect_with(
+        &self,
+        config: quinn::ClientConfig,
+        addr: &SocketAddr,
+        server_name: &str,
+    ) -> Result<
+        impl Future<
+            Item = (
+                quinn::ConnectionDriver,
+                quinn::Connection,
+                quinn::IncomingStreams,
+            ),
+            Error = quinn::ConnectionError,
+        >,
+        quinn::ConnectError,
+    > {
+        let connecting_res = self.0.connect_with(config, addr, server_name)?;
+        let delay_ms = test_ctx(|ctx| ctx.connect_delay);
+        if delay_ms > 0 {
+            Ok(Either::A(
+                Delay::new(Instant::now() + Duration::from_millis(delay_ms))
+                    .then(move |_| connecting_res),
+            ))
+        } else {
+            Ok(Either::B(connecting_res))
+        }
+    }
+}
+
+impl<'a> Deref for EndpointWrap<'a> {
+    type Target = quinn::Endpoint;
+
+    fn deref(&self) -> &quinn::Endpoint {
+        self.0
+    }
+}
+
+impl Context {
+    pub(crate) fn quic_ep(&self) -> EndpointWrap {
+        EndpointWrap(&self.quic_ep)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct TestContext {
+    connect_delay: u64,
+}
 
 /// Extend `QuicP2p` with test functions.
 impl QuicP2p {
+    pub(crate) fn set_connect_delay(&mut self, delay_ms: u64) {
+        self.el
+            .post(move || test_ctx_mut(|ctx| ctx.connect_delay = delay_ms));
+    }
+
     /// Send an arbitrary message. Used for testing malicious nodes and clients.
     pub(crate) fn send_wire_msg(&mut self, peer: Peer, msg: WireMsg) {
         self.el.post(move || {
             communicate::try_write_to_peer(peer, msg);
         });
+    }
+
+    /// Returns a list of connections of this peer.
+    pub(crate) fn connections<F: Send + 'static, Res: Send + 'static>(&mut self, f: F) -> R<Res>
+    where
+        F: FnOnce(&HashMap<SocketAddr, Connection>) -> Res,
+    {
+        let (tx, rx) = mpsc::channel();
+        self.el.post(move || {
+            let res = ctx(|c| f(&c.connections));
+            let _ = tx.send(res);
+        });
+        Ok(rx.recv()?)
     }
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,177 @@
+// Copyright 2019 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+use crate::bootstrap_cache::BootstrapCache;
+use crate::config::{Config, OurType, SerialisableCertificate};
+use crate::connection::{FromPeer, QConn, ToPeer};
+use crate::context::{ctx, initialise_ctx, Context};
+use crate::event::Event;
+use crate::event_loop::EventLoop;
+use crate::wire_msg::WireMsg;
+use crate::{communicate, listener, peer_config, Builder, NodeInfo, Peer, QuicP2p, R};
+use std::collections::HashSet;
+use std::mem;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
+use std::sync::mpsc::{self, Receiver, Sender};
+use tokio::prelude::Future;
+use tokio::runtime::current_thread;
+
+/// Creates a new `QuicP2p` instance for testing.
+pub(crate) fn new_random_qp2p_for_unit_test(
+    is_addr_unspecified: bool,
+    contacts: HashSet<NodeInfo>,
+) -> (QuicP2p, Receiver<Event>) {
+    let (tx, rx) = mpsc::channel();
+    let qp2p = {
+        let mut cfg = Config::with_default_cert();
+        cfg.hard_coded_contacts = contacts;
+        cfg.port = Some(0);
+        if !is_addr_unspecified {
+            cfg.ip = Some(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        }
+        unwrap!(Builder::new(tx).with_config(cfg).build())
+    };
+
+    (qp2p, rx)
+}
+
+/// Connect and open a bi-directional stream.
+/// This will fail if we don't have a connection to the peer or if the peer is in an invalid state
+/// to be sent a message to.
+pub(crate) fn write_to_bi_stream(peer_addr: SocketAddr, wire_msg: WireMsg) {
+    fn write_to_bi(conn: &QConn, wire_msg: WireMsg) {
+        let leaf = conn
+            .open_bi()
+            .map_err(move |e| panic!("Open-Bidirectional: {:?} {}", e, e))
+            .and_then(move |(o_stream, _i_stream)| {
+                tokio::io::write_all(o_stream, wire_msg.into())
+                    .map_err(move |e| panic!("Write-All: {:?} {}", e, e))
+            })
+            .and_then(move |(o_stream, _): (_, bytes::Bytes)| {
+                tokio::io::shutdown(o_stream)
+                    .map_err(move |e| panic!("Shutdown-after-write: {:?} {}", e, e))
+            })
+            .map(|_| ());
+        current_thread::spawn(leaf);
+    }
+
+    ctx(|c| {
+        let conn = match c.connections.get(&peer_addr) {
+            Some(conn) => conn,
+            None => panic!("Asked to communicate with an unknown peer: {}", peer_addr),
+        };
+
+        match &conn.to_peer {
+            ToPeer::NotNeeded => {
+                if let FromPeer::Established { ref q_conn, .. } = conn.from_peer {
+                    write_to_bi(q_conn, wire_msg);
+                } else {
+                    panic!(
+                        "TODO We cannot communicate with someone we are not needing to connect to \
+                         and they are not connected to us just now. Peer: {}",
+                        peer_addr
+                    );
+                }
+            }
+            ToPeer::Established { ref q_conn, .. } => write_to_bi(q_conn, wire_msg),
+            ToPeer::NoConnection | ToPeer::Initiated { .. } => {
+                panic!(
+                    "Peer {} is in invalid state {:?} to be communicated to",
+                    peer_addr, conn.to_peer
+                );
+            }
+        }
+    })
+}
+
+/// Mock `QuicP2p`, used for testing malicious client scenarios.
+pub(crate) struct TestClient {
+    event_tx: Sender<Event>,
+    el: EventLoop,
+}
+
+impl TestClient {
+    /// Create a test client
+    pub fn new(event_tx: Sender<Event>) -> Self {
+        let el = EventLoop::spawn();
+        Self { event_tx, el }
+    }
+
+    /// Must be called only once. There can only be one context per `TestClient` instance.
+    pub fn activate(&mut self, our_type: OurType) -> R<()> {
+        let tx = self.event_tx.clone();
+
+        let ((key, cert), our_complete_cert) = {
+            let our_complete_cert: SerialisableCertificate = Default::default();
+            (
+                our_complete_cert.obtain_priv_key_and_cert(),
+                our_complete_cert,
+            )
+        };
+
+        let (err_tx, err_rx) = mpsc::channel::<R<()>>();
+        self.el.post(move || {
+            let our_cfg = unwrap!(peer_config::new_our_cfg(
+                peer_config::DEFAULT_IDLE_TIMEOUT_MSEC,
+                peer_config::DEFAULT_KEEP_ALIVE_INTERVAL_MSEC,
+                cert,
+                key
+            ));
+
+            let mut ep_builder = quinn::Endpoint::builder();
+            ep_builder.listen(our_cfg);
+            let (dr, ep, incoming_connections) = {
+                match UdpSocket::bind(&(Ipv4Addr::LOCALHOST, 0)) {
+                    Ok(udp) => unwrap!(ep_builder.with_socket(udp)),
+                    Err(e) => {
+                        panic!("Could not bind a random port! Error: {:?}- {}", e, e);
+                    }
+                }
+            };
+
+            let mut bootstrap_cache =
+                unwrap!(BootstrapCache::new(Default::default(), Default::default()));
+
+            // Do not use the bootstrap cache.
+            mem::replace(bootstrap_cache.peers_mut(), Default::default());
+
+            let ctx = Context::new(
+                tx,
+                our_complete_cert,
+                crate::DEFAULT_MAX_ALLOWED_MSG_SIZE,
+                peer_config::DEFAULT_IDLE_TIMEOUT_MSEC,
+                peer_config::DEFAULT_KEEP_ALIVE_INTERVAL_MSEC,
+                our_type,
+                bootstrap_cache,
+                ep,
+            );
+
+            initialise_ctx(ctx);
+
+            current_thread::spawn(dr.map_err(|e| warn!("Error in quinn Driver: {:?}", e)));
+
+            if our_type != OurType::Client {
+                listener::listen(incoming_connections);
+            }
+
+            let _ = err_tx.send(Ok(()));
+        });
+
+        (err_rx.recv()?)?;
+
+        Ok(())
+    }
+
+    /// Send an arbitrary message.
+    pub fn send(&mut self, peer: Peer, msg: WireMsg) {
+        self.el.post(move || {
+            communicate::try_write_to_peer(peer, msg);
+        });
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -125,36 +125,3 @@ where
 
     Ok(())
 }
-
-#[cfg(test)]
-pub mod testing {
-    use crate::config::SerialisableCertificate;
-    use crate::dirs::{Dirs, OverRide};
-    use crate::NodeInfo;
-    use rand::Rng;
-    use std::env;
-    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-    use std::path::PathBuf;
-
-    pub fn test_dirs() -> Dirs {
-        Dirs::Overide(OverRide::new(&unwrap!(tmp_rand_dir().to_str())))
-    }
-
-    pub fn rand_node_info() -> NodeInfo {
-        let peer_cert_der = SerialisableCertificate::default().cert_der;
-        let mut rng = rand::thread_rng();
-        let port: u16 = rng.gen();
-        let peer_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port));
-        NodeInfo {
-            peer_addr,
-            peer_cert_der,
-        }
-    }
-
-    fn tmp_rand_dir() -> PathBuf {
-        let fname = format!("quic_p2p_tests_{:016x}", rand::random::<u64>());
-        let mut path = env::temp_dir();
-        path.push(fname);
-        path
-    }
-}

--- a/tests/quic_p2p.rs
+++ b/tests/quic_p2p.rs
@@ -1,5 +1,6 @@
-use quic_p2p::{Builder, Config, Event, Peer, QuicP2p};
-use std::net::{IpAddr, Ipv4Addr};
+use quic_p2p::{Builder, Config, Event, NodeInfo, Peer, QuicP2p};
+use std::collections::{HashSet, VecDeque};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::mpsc;
 use unwrap::unwrap;
 
@@ -15,6 +16,27 @@ fn wait_till_connected(ev_rx: mpsc::Receiver<Event>) -> Peer {
 
 /// Constructs `QuicP2p` instace with some sane defaults for testing.
 fn test_peer() -> (QuicP2p, mpsc::Receiver<Event>) {
+    test_peer_with_hcc(Default::default())
+}
+
+fn test_peer_with_hcc(hard_coded_contacts: HashSet<NodeInfo>) -> (QuicP2p, mpsc::Receiver<Event>) {
+    let (ev_tx, ev_rx) = mpsc::channel();
+    let builder = Builder::new(ev_tx)
+        .with_config(Config {
+            port: Some(0),
+            ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            hard_coded_contacts,
+            ..Default::default()
+        })
+        // Make sure we start with an empty cache. Otherwise, we might get into unexpected state.
+        .with_proxies(Default::default(), true);
+    (unwrap!(builder.build()), ev_rx)
+}
+
+fn test_peer_with_bootstrap_cache(
+    mut cached_peers: Vec<NodeInfo>,
+) -> (QuicP2p, mpsc::Receiver<Event>) {
+    let cached_peers: VecDeque<_> = cached_peers.drain(..).collect();
     let (ev_tx, ev_rx) = mpsc::channel();
     let builder = Builder::new(ev_tx)
         .with_config(Config {
@@ -22,8 +44,7 @@ fn test_peer() -> (QuicP2p, mpsc::Receiver<Event>) {
             ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
             ..Default::default()
         })
-        // Make sure we start with an empty cache. Otherwise, we might get into unexpected state.
-        .with_proxies(Default::default(), true);
+        .with_proxies(cached_peers, true);
     (unwrap!(builder.build()), ev_rx)
 }
 
@@ -70,4 +91,81 @@ fn incoming_connections_are_not_put_into_bootstrap_cache_upon_connected_to_event
 
     let cache = unwrap!(peer1.bootstrap_cache());
     assert!(cache.is_empty());
+}
+
+mod bootstrap {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn it_will_attempt_hard_coded_contacts() {
+        let (mut peer1, _) = test_peer();
+        let peer1_conn_info = unwrap!(peer1.our_connection_info());
+
+        let (mut peer2, ev_rx) = {
+            let mut hcc = HashSet::new();
+            hcc.insert(peer1_conn_info.clone());
+            test_peer_with_hcc(hcc)
+        };
+
+        peer2.bootstrap();
+
+        for event in ev_rx.iter() {
+            if let Event::BootstrappedTo { node } = event {
+                assert_eq!(node, peer1_conn_info);
+                break;
+            }
+        }
+    }
+
+    #[test]
+    fn it_will_attempt_cached_peers() {
+        let (mut peer1, _) = test_peer();
+        let peer1_conn_info = unwrap!(peer1.our_connection_info());
+
+        let (mut peer2, ev_rx) = test_peer_with_bootstrap_cache(vec![peer1_conn_info.clone()]);
+
+        peer2.bootstrap();
+
+        for event in ev_rx.iter() {
+            if let Event::BootstrappedTo { node } = event {
+                assert_eq!(node, peer1_conn_info);
+                break;
+            }
+        }
+    }
+
+    #[test]
+    fn it_will_report_failure_when_bootstrap_cache_and_hard_coded_contacts_are_empty() {
+        let (mut peer, ev_rx) = test_peer();
+
+        peer.bootstrap();
+
+        for event in ev_rx.iter() {
+            if let Event::BootstrapFailure = event {
+                break;
+            }
+        }
+    }
+
+    #[test]
+    fn it_will_report_failure_when_bootstrap_cache_and_hard_coded_contacts_are_invalid() {
+        let dummy_peer_info = NodeInfo {
+            peer_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 37692)),
+            peer_cert_der: vec![1, 2, 3],
+        };
+        let (mut peer, ev_rx) = {
+            let mut hcc = HashSet::new();
+            hcc.insert(dummy_peer_info.clone());
+            test_peer_with_hcc(hcc)
+        };
+
+        peer.bootstrap();
+
+        for event in ev_rx.iter() {
+            if let Event::BootstrapFailure = event {
+                break;
+            }
+        }
+    }
 }


### PR DESCRIPTION
1. Attempt to open a bi-directional QUIC stream;
2. Attempt to send an extra handshake message, reintroducing a client as a node and vice versa.