### PR TITLE
return unsent messages

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -12,6 +12,10 @@ pub enum Event {
     ConnectionFailure {
         peer_addr: SocketAddr,
     },
+    UnsentUserMessage {
+        peer_addr: SocketAddr,
+        msg: bytes::Bytes,
+    },
     ConnectedTo {
         peer: Peer,
     },

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -38,7 +38,7 @@ fn handle_new_conn(
     let peer_addr = q_conn.remote_address();
 
     current_thread::spawn(conn_driver.map_err(move |e| {
-        utils::handle_communication_err(peer_addr, &From::from(e), "Driver failed");
+        utils::handle_communication_err(peer_addr, &From::from(e), "Driver failed", None);
     }));
 
     let is_duplicate = ctx_mut(|c| {


### PR DESCRIPTION
User messages unable to be delivered will be returned back to the user.
Currently this will happen only in cases where there was a prior connection already and they attempted to write something to it.
All messages falied to be sent would be returned.

A future work to this PR should also see even those messages to be returned when connection attempt failed or the user invoked an illegal API (e.g., trying to send to an unconnected client where no connection attempt is made on send - this attempt is made on.y for nodes because clients are deemed not reverse connectible). Currently these two case would swallow the message. However for the rest of (majority of) cases, the unsent user messages would be returned).

Also note that without App level ACKs there is no guaranteed way to know if these failed. In most cases when we get an error while sending it would actually mean that the message was not entirely sent, so likely discarded at the peer end. However due to network anomalies it might happen that it was sent and then some disruption happened which prevented us from knowing the message was actually delivered. Again, these would be minority of the cases and if such robustness is required we should use App level ACKs which quic-p2p doesn't currently have.