### PR TITLE
fix: handle key and certificate parse errors

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -106,12 +106,11 @@ pub struct SerialisableCertificate {
 }
 
 impl SerialisableCertificate {
-    // TODO do proper error handling
-    pub fn obtain_priv_key_and_cert(&self) -> (quinn::PrivateKey, quinn::Certificate) {
-        (
-            unwrap!(quinn::PrivateKey::from_der(&self.key_der)),
-            unwrap!(quinn::Certificate::from_der(&self.cert_der)),
-        )
+    pub fn obtain_priv_key_and_cert(&self) -> R<(quinn::PrivateKey, quinn::Certificate)> {
+        Ok((
+            quinn::PrivateKey::from_der(&self.key_der)?,
+            quinn::Certificate::from_der(&self.cert_der)?,
+        ))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ impl QuicP2p {
                 .clone()
                 .unwrap_or_else(Default::default);
             (
-                our_complete_cert.obtain_priv_key_and_cert(),
+                our_complete_cert.obtain_priv_key_and_cert()?,
                 our_complete_cert,
             )
         };


### PR DESCRIPTION
Addresses a TODO to handle an error from parsing key material