### PR TITLE
Enable standard lints and fix resulting issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ before_script:
     fi
   - rustup component add rustfmt clippy
 script:
-  - cargo fmt -- --check
   - if [ "${TRAVIS_OS_NAME}" = linux ]; then
-      cargo clippy --verbose --release --all-targets ;
+      scripts/lints ;
     fi
   - cargo test --verbose --release
 before_cache:

--- a/scripts/lints
+++ b/scripts/lints
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -x -e
+export RUSTFLAGS="-C opt-level=2 -C codegen-units=8"
+
+cargo fmt -- --check
+cargo clippy --verbose --release --all-targets

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -71,8 +71,8 @@ mod tests {
 
             let ci_info = unwrap!(qp2p.our_connection_info());
 
-            bs_peer_addrs.insert(ci_info.peer_addr);
-            hcc_contacts.insert(ci_info);
+            assert!(bs_peer_addrs.insert(ci_info.peer_addr));
+            assert!(hcc_contacts.insert(ci_info));
             bs_nodes.push((rx, qp2p));
         }
 
@@ -172,9 +172,8 @@ mod tests {
 
         let bootstrap_ci = unwrap!(bootstrap_node.our_connection_info());
 
-        //
         let mut hcc = HashSet::with_capacity(1);
-        hcc.insert(bootstrap_ci.clone());
+        assert!(hcc.insert(bootstrap_ci.clone()));
 
         let (ev_tx, ev_rx) = mpmc::unbounded();
         let mut bootstrap_client = unwrap!(Builder::new(ev_tx)
@@ -206,7 +205,7 @@ mod tests {
 
         let (mut peer2, ev_rx) = {
             let mut hcc = HashSet::new();
-            hcc.insert(peer1_conn_info.clone());
+            assert!(hcc.insert(peer1_conn_info.clone()));
             test_peer_with_hcc(hcc, OurType::Node)
         };
 
@@ -240,7 +239,7 @@ mod tests {
 
         let (mut peer2, ev_rx) = {
             let mut hcc = HashSet::new();
-            hcc.insert(peer1_conn_info.clone());
+            assert!(hcc.insert(peer1_conn_info.clone()));
             test_peer_with_hcc(hcc, OurType::Client)
         };
 
@@ -305,7 +304,7 @@ mod tests {
         };
         let (mut peer, ev_rx) = {
             let mut hcc = HashSet::new();
-            hcc.insert(dummy_peer_info.clone());
+            assert!(hcc.insert(dummy_peer_info.clone()));
             test_peer_with_hcc(hcc, OurType::Node)
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,11 +101,18 @@ impl Config {
 /// configuration file
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct SerialisableCertificate {
+    /// DER encoded certificate
     pub cert_der: Vec<u8>,
+    /// DER encoded private key
     pub key_der: Vec<u8>,
 }
 
 impl SerialisableCertificate {
+    /// Parses DER encoded binary key material to a format that can be used by Quinn
+    ///
+    /// # Errors
+    /// Returns [CertificateParseError](enum.Error.html#variant.CertificateParseError) if the inputs
+    /// cannot be parsed
     pub fn obtain_priv_key_and_cert(&self) -> R<(quinn::PrivateKey, quinn::Certificate)> {
         Ok((
             quinn::PrivateKey::from_der(&self.key_der)?,

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -117,7 +117,7 @@ fn spawn_incomplete_conn_killer(peer_addr: SocketAddr) {
                         "Killing a non-completing connection for peer: {}",
                         peer_addr
                     );
-                    conn.remove();
+                    let _ = conn.remove();
                 }
             });
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,59 +13,75 @@ use std::sync::mpsc;
 
 quick_error! {
     #[derive(Debug)]
+     /// Error types encountered during the operation of this library.
      pub enum Error {
+         /// Error type associated with I/O operations.
          Io(e: io::Error) {
              display("IO Error: {}", e)
              from()
          }
+         /// Errors encountered while reading from a QUIC stream.
          Read(e: quinn::ReadError) {
              display("Read Error: {}", e)
              from()
          }
+         /// Error returned when a Bi-directional stream is attempted by a peer.
          BiDirectionalStreamAttempted(peer_addr: SocketAddr) {
              display("Bi-directional stream attempted by peer {}", peer_addr)
          }
+         /// Errors encountered while creating a new connection.
          Connect(e: quinn::ConnectError) {
              display("Connection Error: {}", e)
              from()
          }
+         /// Errors explaining why an established connection might be lost.
          Connection(e: quinn::ConnectionError) {
              display("Connection Error: {}", e)
              from()
          }
+         /// Errors encountered while creating a new endpoint.
          Endpoint(e: quinn::EndpointError) {
              display("Endpoint error: {}", e)
              from()
          }
+         /// Error encountered while parsing a certificate or key.
          CertificateParseError(e: quinn::tls::ParseError) {
              display("Certificate Parse Error: {}", e)
              from()
          }
+         /// Error returned when a duplicate connection to a peer is attempted.
          DuplicateConnectionToPeer(peer_addr: SocketAddr) {
              display("Duplicate connection attempted to peer {}", peer_addr)
          }
+         /// Error returned when an endpoint echo server is not found.
          NoEndpointEchoServerFound {
              display("There's no endpoint echo server to ask. Current network configuration")
          }
+         /// Error returned when a receive operation on a channel fails.
          OneShotRx(e: tokio::sync::oneshot::error::RecvError) {
              display("Oneshot Receiver error: {}", e)
              from()
          }
+         /// Errors encountered while establishing TLS.
          TLS(e: rustls::TLSError) {
              display("TLE error: {}", e)
              from()
          }
+         /// Error produced when (de)serialisation is unsuccessful.
          Bincode(e: bincode::Error) {
              display("Bincode error: {}", e)
              from()
          }
+         /// Errors encountered while decoding Base64 values.
          Base64(e: base64::DecodeError) {
              display("Base64 decoding error: {}", e)
              from()
          }
+         /// Error produced when configuration is not understood.
          Configuration(e: String) {
              display("Configuration error: {}", e)
          }
+         /// Error encountered while creating a new connection
          OperationNotAllowed {
              display("This operation is not allowed for us")
          }

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,22 +5,35 @@ use std::net::SocketAddr;
 /// QuicP2p Events to the user
 #[derive(Debug)]
 pub enum Event {
+    /// Network bootstrap failed.
     BootstrapFailure,
+    /// Bootstrap connection to this node was successful.
     BootstrappedTo {
+        /// Node information.
         node: NodeInfo,
     },
+    /// Connection to this peer failed.
     ConnectionFailure {
+        /// Peer address.
         peer_addr: SocketAddr,
     },
+    /// The given message was not sent to this peer.
     UnsentUserMessage {
+        /// Peer address.
         peer_addr: SocketAddr,
+        /// Unsent message.
         msg: bytes::Bytes,
     },
+    /// Successfully connected to this peer.
     ConnectedTo {
+        /// Peer information.
         peer: Peer,
     },
+    /// A new message was received from this peer.
     NewMessage {
+        /// Sending peer address.
         peer_addr: SocketAddr,
+        /// The new message.
         msg: bytes::Bytes,
     },
     /// No more messages will be fired after this

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,45 @@
 
 // Required for the quick_error! macro
 #![recursion_limit = "128"]
+// For explanation of lint checks, run `rustc -W help`
+#![forbid(
+    exceeding_bitshifts,
+    mutable_transmutes,
+    no_mangle_const_items,
+    unknown_crate_types,
+    warnings
+)]
+#![deny(
+    bad_style,
+    deprecated,
+    improper_ctypes,
+    missing_docs,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    plugin_as_library,
+    stable_features,
+    unconditional_recursion,
+    unknown_lints,
+    unsafe_code,
+    unused,
+    unused_allocation,
+    unused_attributes,
+    unused_comparisons,
+    unused_features,
+    unused_parens,
+    while_true,
+    clippy::unicode_not_nfc,
+    clippy::wrong_pub_self_convention,
+    clippy::option_unwrap_used
+)]
+#![warn(
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results
+)]
 
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+//! quic-p2p enables communication within a peer to peer network over the QUIC protocol.
+
 // Required for the quick_error! macro
 #![recursion_limit = "128"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,11 +294,11 @@ impl QuicP2p {
         let idle_timeout_msec = self
             .cfg
             .idle_timeout_msec
-            .unwrap_or(peer_config::DEFAULT_IDLE_TIMEOUT_MSEC);
+            .unwrap_or(DEFAULT_IDLE_TIMEOUT_MSEC);
         let keep_alive_interval_msec = self
             .cfg
             .keep_alive_interval_msec
-            .unwrap_or(peer_config::DEFAULT_KEEP_ALIVE_INTERVAL_MSEC);
+            .unwrap_or(DEFAULT_KEEP_ALIVE_INTERVAL_MSEC);
         let our_type = self.cfg.our_type;
         let hard_coded_contacts = self.cfg.hard_coded_contacts.clone();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ impl QuicP2p {
             ));
 
             let mut ep_builder = quinn::Endpoint::builder();
-            ep_builder.listen(our_cfg);
+            let _ = ep_builder.listen(our_cfg);
             let (dr, ep, incoming_connections) = {
                 match UdpSocket::bind(&(ip, port)) {
                     Ok(udp) => unwrap!(ep_builder.with_socket(udp)),

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -14,8 +14,16 @@ use std::net::SocketAddr;
 /// Representation of a peer to us.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub enum Peer {
-    Node { node_info: NodeInfo },
-    Client { peer_addr: SocketAddr },
+    /// Stores Node information.
+    Node {
+        /// Information needed to connect to a node.
+        node_info: NodeInfo,
+    },
+    /// Stores client information.
+    Client {
+        /// Address of the client reaching us.
+        peer_addr: SocketAddr,
+    },
 }
 
 impl Peer {

--- a/src/peer_config.rs
+++ b/src/peer_config.rs
@@ -33,7 +33,7 @@ pub fn new_client_cfg(peer_cert_der: &[u8]) -> R<quinn::ClientConfig> {
 
         quinn::ClientConfigBuilder::new(client_cfg)
     };
-    peer_cfg_builder.add_certificate_authority(peer_cert)?;
+    let _ = peer_cfg_builder.add_certificate_authority(peer_cert)?;
 
     Ok(peer_cfg_builder.build())
 }
@@ -53,8 +53,9 @@ pub fn new_our_cfg(
 
         quinn::ServerConfigBuilder::new(our_cfg)
     };
-    our_cfg_builder.certificate(quinn::CertificateChain::from_certs(vec![our_cert]), our_key)?;
-    our_cfg_builder.use_stateless_retry(true);
+    let _ = our_cfg_builder
+        .certificate(quinn::CertificateChain::from_certs(vec![our_cert]), our_key)?
+        .use_stateless_retry(true);
 
     Ok(our_cfg_builder.build())
 }


### PR DESCRIPTION
Adds standard lint rules used by the routing and parsec crates.

Fixes #55 