### PR TITLE
changes due to routing requirements

### DIFF
--- a/examples/bootstrap_node.rs
+++ b/examples/bootstrap_node.rs
@@ -89,7 +89,9 @@ fn main() -> Result<(), io::Error> {
                     let msg = Bytes::from(unwrap!(bincode::serialize(&Rpc::StartTest(contacts))));
                     for peer in connected_peers.values() {
                         // qp2p.send(Peer::Node { node_info: peer.clone() }, msg.clone());
-                        qp2p.send(peer.clone(), msg.clone());
+                        // TODO: Demo tokens properly. Currently just putting 0 here.
+                        // TODO: Also handle receiving `SentUserMessage` event
+                        qp2p.send(peer.clone(), msg.clone(), 0);
                     }
                     test_triggered = true;
                 } else if connected_peers.len() >= expected_connections {

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -149,7 +149,8 @@ fn on_cmd_send<'a>(
         .and_then(|idx| peer_list.get(idx).ok_or("Index out of bounds"))
         .map(|peer| {
             let msg = Bytes::from(args.collect::<Vec<_>>().join(" ").as_bytes());
-            qp2p.send(peer.clone(), msg);
+            // TODO: handle tokens properly. Currently just hardcoding to 0 in example
+            qp2p.send(peer.clone(), msg, 0);
         })
 }
 
@@ -172,7 +173,8 @@ fn on_cmd_send_rand<'a>(
         })
         .map(|(peer, bytes_to_send)| {
             let data = Bytes::from(random_vec(bytes_to_send));
-            qp2p.send(peer.clone(), data)
+            // TODO: handle tokens properly. Currently just hardcoding to 0 in example
+            qp2p.send(peer.clone(), data, 0)
         })
 }
 

--- a/examples/client_node.rs
+++ b/examples/client_node.rs
@@ -117,7 +117,9 @@ impl ClientNode {
         let bootstrap_node = Peer::Node {
             node_info: self.bootstrap_node_info.clone(),
         };
-        self.qp2p.send(bootstrap_node, Bytes::from(vec![1, 2, 3]));
+        // TODO: handle tokens properly. Currently just hardcoding to 0 in example
+        self.qp2p
+            .send(bootstrap_node, Bytes::from(vec![1, 2, 3]), 0);
 
         self.poll_qp2p_events();
     }
@@ -142,8 +144,9 @@ impl ClientNode {
         if peer_info == self.bootstrap_node_info {
             info!("Connected to bootstrap node. Waiting for other node contacts...");
         } else if self.client_nodes.contains(&peer_info) {
-            self.qp2p.send(peer.clone(), self.large_msg.clone());
-            self.qp2p.send(peer, self.small_msg.clone());
+            // TODO: handle tokens properly. Currently just hardcoding to 0 in example
+            self.qp2p.send(peer.clone(), self.large_msg.clone(), 0);
+            self.qp2p.send(peer, self.small_msg.clone(), 0);
             self.sent_messages += 1;
         }
     }

--- a/src/connection/to_peer.rs
+++ b/src/connection/to_peer.rs
@@ -8,7 +8,7 @@
 // Software.
 
 use crate::connection::QConn;
-use crate::utils::ConnectTerminator;
+use crate::utils::{ConnectTerminator, Token};
 use crate::wire_msg::WireMsg;
 use std::fmt;
 
@@ -19,7 +19,7 @@ pub enum ToPeer {
     Initiated {
         terminator: ConnectTerminator,
         peer_cert_der: Vec<u8>,
-        pending_sends: Vec<WireMsg>,
+        pending_sends: Vec<(WireMsg, Token)>,
     },
     Established {
         peer_cert_der: Vec<u8>,

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,6 +2,7 @@ use crate::error::Error;
 use crate::{utils, NodeInfo, Peer};
 use std::fmt;
 use std::net::SocketAddr;
+use utils::Token;
 
 /// QuicP2p Events to the user
 #[derive(Debug)]
@@ -20,12 +21,23 @@ pub enum Event {
         /// Error explaining connection failure.
         err: Error,
     },
+    /// The given message was successfully sent to this peer.
+    SentUserMessage {
+        /// Peer address.
+        peer_addr: SocketAddr,
+        /// Sent message.
+        msg: bytes::Bytes,
+        /// Token, originally given by the user, for context.
+        token: Token,
+    },
     /// The given message was not sent to this peer.
     UnsentUserMessage {
         /// Peer address.
         peer_addr: SocketAddr,
         /// Unsent message.
         msg: bytes::Bytes,
+        /// Token, originally given by the user, for context.
+        token: Token,
     },
     /// Successfully connected to this peer.
     ConnectedTo {
@@ -56,7 +68,7 @@ impl fmt::Display for Event {
                 peer_addr,
                 utils::bin_data_format(&*msg)
             ),
-            ref blah => write!(f, "{}", blah),
+            _ => write!(f, "TODO"),
         }
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -13,7 +13,7 @@ use crate::context::ctx;
 use crate::context::Context;
 use crate::dirs::{Dirs, OverRide};
 use crate::event::Event;
-use crate::utils::R;
+use crate::utils::{Token, R};
 use crate::wire_msg::WireMsg;
 use crate::{communicate, Builder, NodeInfo, Peer, QuicP2p};
 use crossbeam_channel as mpmc;
@@ -146,9 +146,9 @@ impl QuicP2p {
     }
 
     /// Send an arbitrary message. Used for testing malicious nodes and clients.
-    pub(crate) fn send_wire_msg(&mut self, peer: Peer, msg: WireMsg) {
+    pub(crate) fn send_wire_msg(&mut self, peer: Peer, msg: WireMsg, token: Token) {
         self.el.post(move || {
-            communicate::try_write_to_peer(peer, msg);
+            communicate::try_write_to_peer(peer, msg, token);
         });
     }
 


### PR DESCRIPTION
Take a token from the user and return it during, both, send successes and failures, along with the message and the peer that the send attempt was made to