### PR TITLE
fix/wire_msg: fix incorrect serialisation logic in WireMsg

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -85,16 +85,20 @@ quick_error! {
          OperationNotAllowed {
              display("This operation is not allowed for us")
          }
-        /// Connection Cancelled
-        ConnectionCancelled {
-            display("Connection was actively cancelled")
-            from()
-        }
-        /// Failed receiving from an `mpsc::channel`.
-        ChannelRecv(e: mpsc::RecvError) {
-            display("Channel receive error: {}", e)
-            cause(e)
-            from()
-        }
+         /// Connection Cancelled
+         ConnectionCancelled {
+             display("Connection was actively cancelled")
+             from()
+         }
+         /// Failed receiving from an `mpsc::channel`.
+         ChannelRecv(e: mpsc::RecvError) {
+             display("Channel receive error: {}", e)
+             cause(e)
+             from()
+         }
+         /// Could not deserialise a wire message.
+         InvalidWireMsgFlag {
+             display("Could not deserialise a wire message: unexpected message type flag")
+         }
      }
 }


### PR DESCRIPTION
While deserialising messages, we wrongly assumed that all messages >1 KB in size are not serialised and are plain user messages. However, `bincode::serialise(wire_msg)` also could have produced messages over 1 KB, which resulted in deserialisation failures in the user code.

To fix this, we added a one-byte flag that will clearly identify pre-serialised user messages and messages that are sent by quic-p2p itself. With that, the serialisation logic becomes even more efficient now because we don't need to serialise _all_ user messages which are likely to be serialised already.