### PR TITLE
Unsent messages and disconnections

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -47,7 +47,7 @@ pub fn connect_to(
         let conn = c.connections.entry(peer_addr).or_insert_with(|| {
             Connection::new(
                 peer_addr,
-                event_tx,
+                event_tx.clone(),
                 bootstrap_group_maker
                     .map(|m| m.add_member_and_get_group_ref(peer_addr, terminator.clone())),
             )
@@ -74,8 +74,10 @@ pub fn connect_to(
             }
             conn.to_peer = ToPeer::Initiated {
                 terminator: terminator.clone(),
+                peer_addr,
                 peer_cert_der: peer_info.peer_cert_der,
                 pending_sends,
+                event_tx,
             };
             c.quic_ep()
                 .connect_with(peer_cfg, &peer_addr, "MaidSAFE.net")

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -73,8 +73,9 @@ impl Connection {
 
 impl Drop for Connection {
     fn drop(&mut self) {
-        if (self.to_peer.is_established() || self.to_peer.is_not_needed())
-            && (self.from_peer.is_established() || self.from_peer.is_not_needed())
+        if self.we_contacted_peer
+            || ((self.to_peer.is_established() || self.to_peer.is_not_needed())
+                && (self.from_peer.is_established() || self.from_peer.is_not_needed()))
         {
             // No need to log these as this will fire even when the QuicP2p handle is dropped and at
             // that point there might be no one listening so sender will error out

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,7 +39,7 @@ quick_error! {
              display("Connection Error: {}", e)
              from()
          }
-         /// Errors encountered while creating a new endpoint.
+         /// Error while creating a quinn endpoint
          Endpoint(e: quinn::EndpointError) {
              display("Endpoint error: {}", e)
              from()
@@ -81,7 +81,7 @@ quick_error! {
          Configuration(e: String) {
              display("Configuration error: {}", e)
          }
-         /// Error encountered while creating a new connection
+         /// Forbidden operation attempted
          OperationNotAllowed {
              display("This operation is not allowed for us")
          }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -148,7 +148,7 @@ impl QuicP2p {
     /// Send an arbitrary message. Used for testing malicious nodes and clients.
     pub(crate) fn send_wire_msg(&mut self, peer: Peer, msg: WireMsg, token: Token) {
         self.el.post(move || {
-            communicate::try_write_to_peer(peer, msg, token);
+            unwrap!(communicate::try_write_to_peer(peer, msg, token));
         });
     }
 


### PR DESCRIPTION
Following features which were missing are now added:

0. Unsent user messages in the pending queues of an ongoing connection attempt will now be sent back to the user library if the connection attempt fails.
1. Report connection failure for all cases where the connection was initiated by us. Previously some of the cases where not handled.
2. Fire unsent user messages to the clients back to the user library. Previously unsent messages to clients were silently ignored.