### PR TITLE
Use single endpoint for each quic-p2p instance

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -21,6 +21,7 @@ const CERT_SERVER_NAME: &str = "MaidSAFE.net";
 
 /// Endpoint instance which can be used to create connections to peers,
 /// and listen to incoming messages from other peers.
+#[derive(Clone)]
 pub struct Endpoint {
     local_addr: SocketAddr,
     quic_endpoint: quinn::Endpoint,


### PR DESCRIPTION
- all connections will be created using this end point